### PR TITLE
fix: ui edge cases

### DIFF
--- a/scripts/services/overlayVisualiser.js
+++ b/scripts/services/overlayVisualiser.js
@@ -192,6 +192,7 @@ export class OverlayVisualiser {
                 align-items: center !important;
                 justify-content: center !important;
                 border-width: ${opts.outlinescaleunpressed ?? 1}px !important;
+                transform: scale(1) !important;
             }
             .key, .mouse-btn { overflow: hidden !important; }
             .scroll-display { overflow: visible !important; }
@@ -227,7 +228,7 @@ export class OverlayVisualiser {
                 color: ${opts.fontcolor} !important;
                 transform: ${activeTransform} !important;
                 border-color: ${opts.activecolor} !important;
-                box-shadow: 0 2px ${opts.glowradius}px ${opts.activecolor} !important;
+                box-shadow: 0 0 ${opts.glowradius}px ${opts.activecolor} !important;
                 border-width: ${opts.outlinescalepressed ?? 1}px !important;
             }
             .key.active:not(.analog-key), .mouse-btn.active:not(.analog-key), .scroll-display.active:not(.analog-key) {


### PR DESCRIPTION
Fixed middle key row size mismatch after first activation (hacky way, the box and div rendering delta on the qwerty row is still present for some reason but it's gone elsewhere)
Fixed bottom height of box shadow being visible with glow color when glow rad and border rad are 0. (visible on 3a948768 and prior with [this](https://overlay.girlglock.com/?cfg=eNplUNuO0zAQ_Zd58FMrxblQGCkPYdkVSK20dCvxiJzYbq1142A7W_oBiM9A_CGfgC8UumzmIcdn5pw5Nhu8ehKD0ca2K14UUhI1sivydRGL9Gx43FszjzzTlMXilOTZfp_pol5V_RtiZq_V-MehlrGINKPPhEwf2WtzagtiGVezC2Cywjk3MC1aWjTETULwltYF2bPpaLiSSgSz8mKeJpMmjBXP2Hn8x8e1kh2VPredVUzfq69Ck95oHjstJUczO-EtU9qJ0alwG-XPIQEl7mBOqcuV82wcxGX6cuaTapumIMPsvDmu2TmE2JoTbR_F-XOMMgkENT4pB4tIUQSaUYlQZlQhVBnVCDX871UmL896hF33FnCmyyZNf0H4mHUnhE8ZhW23GVmE7QuvKnlpIb07KOkRHt5_uNsFzzJpGEKX1S60MuII7zKSCHcvHJu_joO3GuFmt11fZYwNpsOibr27ot3EhhD14b67uQ10tayqZ8ab-MZteulkgbChMeWyXi3cYI3WItxvUwHCrx8_v-Xfd1hkhVX7Q5SUF0mmJ8ZxbuK2-hWyZa9_A_N_CNM) config as an obvious example.