### PR TITLE
feat: Let distance reset after trail-fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -798,7 +798,7 @@
                             <div class="cfg-section-title">mouse pad<div class="cs-hr"></div>
                             </div>
                             <div class="cfg-slider-trio">
-                                <div class="cfg-field" id="mousepadtexture-field" style="margin-top:8px">
+                                <div class="cfg-field" id="mousetrailmode-field" style="margin-top:8px">
                                     <label class="cfg-label" for="mousetrailmode">mode</label>
                                     <select id="mousetrailmode" class="cfg-select config-input">
                                         <option value="wrap">wrap</option>

--- a/index.html
+++ b/index.html
@@ -797,7 +797,7 @@
                         <div class="cfg-section">
                             <div class="cfg-section-title">mouse pad<div class="cs-hr"></div>
                             </div>
-                            <div class="cfg-slider-trio">
+                            <div class="cfg-slider-quad">
                                 <div class="cfg-field" id="mousetrailmode-field" style="margin-top:8px">
                                     <label class="cfg-label" for="mousetrailmode">mode</label>
                                     <select id="mousetrailmode" class="cfg-select config-input">
@@ -814,6 +814,11 @@
                                     <input type="checkbox" class="config-input" id="showmousedistance">
                                     <span class="cfg-checkbox-box"></span>
                                     <span class="cfg-checkbox-label">show dist tracker</span>
+                                </label>
+                                <label class="cfg-checkbox" style="margin-top:25px">
+                                    <input type="checkbox" class="config-input" id="resetmousedistanceafterfade">
+                                    <span class="cfg-checkbox-box"></span>
+                                    <span class="cfg-checkbox-label" id="resetmousedistanceafterfadelabel">reset dist tracker after fadeout</span>
                                 </label>
                             </div>
                             <div class="cfg-slider-pair">

--- a/scripts/services/configurator.js
+++ b/scripts/services/configurator.js
@@ -75,6 +75,7 @@ export class ConfiguratorMode {
             mousepadtextureopacity: "1",
             showmousedistance: false,
             mousedistancedpi: "400",
+            resetmousedistanceafterfade: false,
         });
     }
 
@@ -132,6 +133,7 @@ export class ConfiguratorMode {
             mousepadtextureopacity: val("mousepadtextureopacity") || "1",
             showmousedistance: chk("showmousedistance"),
             mousedistancedpi: val("mousedistancedpi") || "400",
+            resetmousedistanceafterfade: chk("resetmousedistanceafterfade"),
         };
     }
 
@@ -226,6 +228,7 @@ export class ConfiguratorMode {
         applyValue("mousepadtextureopacity", settings.mousepadtextureopacity ?? "1");
         applyValue("showmousedistance", settings.showmousedistance ?? false);
         applyValue("mousedistancedpi", settings.mousedistancedpi ?? "400");
+        applyValue("resetmousedistanceafterfade", settings.resetmousedistanceafterfade ?? false);
     }
 
     updateState(settings = null) {
@@ -386,12 +389,17 @@ export class ConfiguratorMode {
         wsauthEl.addEventListener("input", () => localStorage.setItem("overlay_wsauth", wsauthEl.value));
 
         const distanceCheckbox = document.getElementById("showmousedistance");
+        const distanceResetCheckbox = document.getElementById("resetmousedistanceafterfade");
+        const distanceResetLabel = document.getElementById("resetmousedistanceafterfadelabel");
         const dpiSlider = document.getElementById("mousedistancedpi");
         const dpiLabel = document.getElementById("mousedistancedpivalue");
         const syncDpiState = () => {
             const enabled = distanceCheckbox?.checked ?? false;
             if (dpiSlider) { dpiSlider.disabled = !enabled; dpiSlider.style.opacity = enabled ? "1" : "0.5"; }
             if (dpiLabel) dpiLabel.style.opacity = enabled ? "1" : "0.4";
+
+            if (distanceResetCheckbox) { distanceResetCheckbox.disabled = !enabled; distanceResetCheckbox.style.opacity = enabled ? "1" : "0.5"; }
+            if (distanceResetLabel) distanceResetLabel.style.opacity = enabled ? "1" : "0.4";
         };
         distanceCheckbox?.addEventListener("change", syncDpiState);
         syncDpiState();

--- a/scripts/services/overlayVisualiser.js
+++ b/scripts/services/overlayVisualiser.js
@@ -36,6 +36,7 @@ export class OverlayVisualiser {
         this.MOUSEPAD_TEXTURE_OPACITY = 1;
         this.MOUSEPAD_SHOW_DISTANCE = false;
         this.MOUSEPAD_DPI = 400;
+        this.MOUSEPAD_RESET_DISTANCE_AFTER_FADE = false;
         this._mousePadTotalDistancePx = 0;
         this.MOUSEPAD_PAN_X = 0;
         this.MOUSEPAD_PAN_Y = 0;
@@ -139,6 +140,7 @@ export class OverlayVisualiser {
         this.MOUSEPAD_M1_HIGHLIGHT = opts.mousetrailm1highlight === true || opts.mousetrailm1highlight === "true" || opts.mousetrailm1highlight === "1";
         this.MOUSEPAD_SHOW_DISTANCE = opts.showmousedistance === true || opts.showmousedistance === "true" || opts.showmousedistance === "1";
         this.MOUSEPAD_DPI = parseInt(opts.mousedistancedpi) || 400;
+        this.MOUSEPAD_RESET_DISTANCE_AFTER_FADE = opts.resetmousedistanceafterfade === true || opts.resetmousedistanceafterfade === "true" || opts.resetmousedistanceafterfade === "1";
 
         const newTextureUrl = opts.mousepadtexture || "";
         const newTextureZoom = parseFloat(opts.mousepadtexturezoom) || 1;
@@ -1152,6 +1154,8 @@ export class OverlayVisualiser {
         if (this.mousePadTrail.length > 0 && this.mousePadTrail.every(p => p === null)) this.mousePadTrail = [];
         const trailEmpty = this.mousePadTrail.length === 0;
         const hasLiveTrail = (!trailEmpty && (noFadeout ? true : idleFade > 0)) || (this.MOUSEPAD_SHOW_DISTANCE && !trailEmpty);
+		
+		if (this.MOUSEPAD_RESET_DISTANCE_AFTER_FADE && !hasLiveTrail) this._mousePadTotalDistancePx = 0;
 
         if (this._mousePadWasLiveTrail && !hasLiveTrail) {
             this.mousePadTrail = [];

--- a/scripts/services/urlManager.js
+++ b/scripts/services/urlManager.js
@@ -126,6 +126,9 @@ export class UrlManager {
         if (settings.mousedistancedpi && settings.mousedistancedpi !== "400") {
             addParam("mousedistancedpi", settings.mousedistancedpi);
         }
+        if (settings.resetmousedistanceafterfade === true || settings.resetmousedistanceafterfade === "true" || settings.resetmousedistanceafterfade === "1") {
+            params.push("resetmousedistanceafterfade=1");
+        }
 
         this.addCustomLayoutParams(params, settings);
 
@@ -182,6 +185,7 @@ export class UrlManager {
                     mousepadtextureopacity: decompressedParams.get("mousepadtextureopacity") || "1",
                     showmousedistance: decompressedParams.get("showmousedistance") === "1",
                     mousedistancedpi: decompressedParams.get("mousedistancedpi") || "400",
+                    resetmousedistanceafterfade: decompressedParams.get("resetmousedistanceafterfade") === "1",
                     customLayoutRow1: decompressedParams.has("customLayoutRow1") ? decompressedParams.get("customLayoutRow1") : DEFAULT_LAYOUT_STRINGS.row1,
                     customLayoutRow2: decompressedParams.has("customLayoutRow2") ? decompressedParams.get("customLayoutRow2") : DEFAULT_LAYOUT_STRINGS.row2,
                     customLayoutRow3: decompressedParams.has("customLayoutRow3") ? decompressedParams.get("customLayoutRow3") : DEFAULT_LAYOUT_STRINGS.row3,
@@ -228,6 +232,7 @@ export class UrlManager {
             mousepadtextureopacity: params.get("mousepadtextureopacity") || "1",
             showmousedistance: params.get("showmousedistance") === "1",
             mousedistancedpi: params.get("mousedistancedpi") || "400",
+            resetmousedistanceafterfade: params.get("resetmousedistanceafterfade") === "1",
             customLayoutRow1: params.has("customLayoutRow1") ? params.get("customLayoutRow1") : DEFAULT_LAYOUT_STRINGS.row1,
             customLayoutRow2: params.has("customLayoutRow2") ? params.get("customLayoutRow2") : DEFAULT_LAYOUT_STRINGS.row2,
             customLayoutRow3: params.has("customLayoutRow3") ? params.get("customLayoutRow3") : DEFAULT_LAYOUT_STRINGS.row3,

--- a/style.css
+++ b/style.css
@@ -723,6 +723,13 @@ li {
     margin-bottom: 8px;
 }
 
+.cfg-slider-quad {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
 .cfg-slider-field {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
First of all, thank you for this tool!
This PR includes two improvements:

1. Mouse Trail Distance Reset: Added functionality to automatically reset the distance counter when the mouse trail fades out.
2. Bug Fix: Corrected a duplicate/invalid ID that was causing issues.

Please review and let me know if any changes are needed. Otherwise, this should be ready to merge.